### PR TITLE
Spec out drawing test.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
   "dependencies": {
     "chai": "*",
     "mocha": "*"
+  },
+  "scripts": {
+    "test" : "mocha"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
     "type": "git",
     "url": "git://github.com/"
   },
-  "dependencies": {}
+  "dependencies": {
+    "chai": "*",
+    "mocha": "*"
+  }
 }

--- a/test/drawingTests.js
+++ b/test/drawingTests.js
@@ -1,52 +1,14 @@
 var assert = require('chai').assert;
-var Parser = require('../main/lib/parser');
 var d = require('../main/lib/drawer');
-var testExamples = require('./fixtures/drawing_fixture');
 
-var tasks = testExamples.tasks;
-var multipleRootTasks = testExamples.multipleRootTasks;
-var multipleBlockingTasks = testExamples.multipleBlockingTasks;
-var unorderedTasks = testExamples.unorderedTasks;
-
-describe('Parser', function() {
-    describe('drawingInstructions()', function() {
-        it('yields drawing instructions ', function() {
-            assert.deepEqual(Parser.getDrawingInstructions(tasks.input), tasks.expected);
-        });
-
-        context('when there are multiple root tasks', function() {
-            it('yeilds drawing instructions for each root', function() {
-                assert.deepEqual(Parser.getDrawingInstructions(multipleRootTasks.input), multipleRootTasks.expected);
-            });
-        });
-
-        context('when there are multiple stories that are blocked on the same task', function() {
-            it('yeilds drawing instructions for each story along with the blocking task', function() {
-                assert.deepEqual(Parser.getDrawingInstructions(multipleBlockingTasks.input), multipleBlockingTasks.expected);
-            });
-        });
-
-        context('when the tasks provided are unordered', function() {
-            it('solves the dependencies and yeilds drawing instructions', function() {
-                assert.deepEqual(Parser.getDrawingInstructions(unorderedTasks.input), unorderedTasks.expected);
-            });
-        });
-    });
-});
+var drawFixture = require('./fixtures/drawing_fixture');
+var drawingTasks = drawFixture.drawingTasks;
 
 describe('Drawer', function () {
     it('draws padding and shanannigansnsgaz', function () {
-        var task = 'IOS-1618';
-
-        var result = d.draw({
-            padding: 1, task: task
-        }, tasks);
-
-        var expected = [
-            d.ARROW,
-            d.DONE,
-            d.jiraLink(task),
-            d.body(tasks[task])].join(" ");
+        var input = drawFixture.sampleDrawing.input;
+        var result = d.draw(input, drawingTasks);
+        var expected = drawFixture.sampleDrawing.expected
 
         assert.equal(result, expected);
     });

--- a/test/drawingTests.js
+++ b/test/drawingTests.js
@@ -1,53 +1,35 @@
 var assert = require('chai').assert;
 var Parser = require('../main/lib/parser');
 var d = require('../main/lib/drawer');
+var testExamples = require('./fixtures/drawing_fixture');
 
-var tasks = {
-    "IOS-1617" : {
-        title: "task a",
-        status: "blocker",
-        owner: "alan",
-        dependsOn: ["IOS-1619"]
-    },
-    "IOS-1619" : {
-        title: "task b",
-        status: "partial",
-        owner: "brandon",
-        dependsOn: ["IOS-1707", "IOS-1618"]
-    },
-    "IOS-1707" : {
-        title: "task c",
-        status: "done",
-        owner: "sonia",
-        dependsOn: []
-    },
-    "IOS-1618" : {
-        title: "task d",
-        status: "done",
-        owner: "amat",
-        dependsOn: []
-    }
-};
+var tasks = testExamples.tasks;
+var multipleRootTasks = testExamples.multipleRootTasks;
+var multipleBlockingTasks = testExamples.multipleBlockingTasks;
+var unorderedTasks = testExamples.unorderedTasks;
 
 describe('Parser', function() {
     describe('drawingInstructions()', function() {
         it('yields drawing instructions ', function() {
-            var expected = [ {
-                padding: 0,
-                task: "IOS-1617"
-            },
-            {   padding: 1,
-                task: "IOS-1619"
-            },
-            {   padding: 2,
-                task: "IOS-1707"
-            },
-            {   padding: 2,
-                task: "IOS-1618"
-            }
-            ];
+            assert.deepEqual(Parser.getDrawingInstructions(tasks.input), tasks.expected);
+        });
 
-            assert.deepEqual(Parser.getDrawingInstructions(tasks), expected);
+        context('when there are multiple root tasks', function() {
+            it('yeilds drawing instructions for each root', function() {
+                assert.deepEqual(Parser.getDrawingInstructions(multipleRootTasks.input), multipleRootTasks.expected);
+            });
+        });
+
+        context('when there are multiple stories that are blocked on the same task', function() {
+            it('yeilds drawing instructions for each story along with the blocking task', function() {
+                assert.deepEqual(Parser.getDrawingInstructions(multipleBlockingTasks.input), multipleBlockingTasks.expected);
+            });
+        });
+
+        context('when the tasks provided are unordered', function() {
+            it('solves the dependencies and yeilds drawing instructions', function() {
+                assert.deepEqual(Parser.getDrawingInstructions(unorderedTasks.input), unorderedTasks.expected);
+            });
         });
     });
 });

--- a/test/fixtures/drawing_fixture.js
+++ b/test/fixtures/drawing_fixture.js
@@ -1,0 +1,212 @@
+module.exports.tasks = {
+    input: {
+        "IOS-1617" : {
+            title: "task a",
+            status: "blocker",
+            owner: "alan",
+            dependsOn: ["IOS-1619"]
+        },
+        "IOS-1619" : {
+            title: "task b",
+            status: "partial",
+            owner: "brandon",
+            dependsOn: ["IOS-1707", "IOS-1618"]
+        },
+        "IOS-1707" : {
+            title: "task c",
+            status: "done",
+            owner: "sonia",
+            dependsOn: []
+        },
+        "IOS-1618" : {
+            title: "task d",
+            status: "done",
+            owner: "amat",
+            dependsOn: []
+        }
+    },
+    expected: [
+        {
+            padding: 0,
+            task: "IOS-1617"
+        },
+        {
+            padding: 1,
+            task: "IOS-1619"
+        },
+        {
+            padding: 2,
+            task: "IOS-1707"
+        },
+        {
+            padding: 2,
+            task: "IOS-1618"
+        }
+    ]
+};
+
+module.exports.multipleRootTasks = {
+    input: {
+        "IOS-1617" : {
+            title: "task a",
+            status: "blocker",
+            owner: "alan",
+            dependsOn: ["IOS-1619"]
+        },
+        "IOS-1619" : {
+            title: "task b",
+            status: "partial",
+            owner: "brandon",
+            dependsOn: ["IOS-1707", "IOS-1618"]
+        },
+        "IOS-1707" : {
+            title: "task c",
+            status: "done",
+            owner: "sonia",
+            dependsOn: []
+        },
+        "IOS-1618" : {
+            title: "task d",
+            status: "done",
+            owner: "amat",
+            dependsOn: []
+        },
+        "IOS-1750" : {
+            title: "task A",
+            status: "partial",
+            owner: "amat",
+            dependsOn: ["IOS-1751"]
+        },
+        "IOS-1751" : {
+            title: "task B",
+            status: "done",
+            owner: "alan",
+            dependsOn: []
+        },
+
+    },
+    expected: [
+        {
+            padding: 0,
+            task: "IOS-1617"
+        },
+        {
+            padding: 1,
+            task: "IOS-1619"
+        },
+        {
+            padding: 2,
+            task: "IOS-1707"
+        },
+        {
+            padding: 2,
+            task: "IOS-1618"
+        },
+        {
+            padding: 0,
+            task: "IOS-1750"
+        },
+        {
+            padding: 1,
+            task: "IOS-1751"
+        }
+    ]
+};
+
+module.exports.multipleBlockingTasks = {
+    input: {
+        "IOS-01" : {
+            title: "task a",
+            status: "partial",
+            owner: "amat",
+            dependsOn: ["IOS-02", "IOS-03"]
+        },
+        "IOS-02" : {
+            title: "task b",
+            status: "blocker",
+            owner: "alan",
+            dependsOn: ["IOS-04"]
+        },
+        "IOS-03" : {
+            title: "task c",
+            status: "blocker",
+            owner: "brandon",
+            dependsOn: ["IOS-04"]
+        },
+        "IOS-04" : {
+            title: "task d",
+            status: "done",
+            owner: "sonia",
+            dependsOn: []
+        }
+    },
+    expected: [
+        {
+            padding: 0,
+            task: "IOS-01"
+        },
+        {
+            padding: 1,
+            task: "IOS-02"
+        },
+        {
+            padding: 2,
+            task: "IOS-04"
+        },
+        {
+            padding: 1,
+            task: "IOS-03"
+        },
+        {
+            padding: 2,
+            task: "IOS-04"
+        }
+    ]
+};
+
+module.exports.unorderedTasks = {
+    input: {
+        "IOS-1618" : {
+            title: "task d",
+            status: "done",
+            owner: "amat",
+            dependsOn: []
+        },
+        "IOS-1617" : {
+            title: "task a",
+            status: "blocker",
+            owner: "alan",
+            dependsOn: ["IOS-1619"]
+        },
+        "IOS-1619" : {
+            title: "task b",
+            status: "partial",
+            owner: "brandon",
+            dependsOn: ["IOS-1707", "IOS-1618"]
+        },
+        "IOS-1707" : {
+            title: "task c",
+            status: "done",
+            owner: "sonia",
+            dependsOn: []
+        }
+    },
+    expected: [
+        {
+            padding: 0,
+            task: "IOS-1617"
+        },
+        {
+            padding: 1,
+            task: "IOS-1619"
+        },
+        {
+            padding: 2,
+            task: "IOS-1707"
+        },
+        {
+            padding: 2,
+            task: "IOS-1618"
+        }
+    ]
+};

--- a/test/fixtures/drawing_fixture.js
+++ b/test/fixtures/drawing_fixture.js
@@ -1,212 +1,41 @@
-module.exports.tasks = {
-    input: {
-        "IOS-1617" : {
-            title: "task a",
-            status: "blocker",
-            owner: "alan",
-            dependsOn: ["IOS-1619"]
-        },
-        "IOS-1619" : {
-            title: "task b",
-            status: "partial",
-            owner: "brandon",
-            dependsOn: ["IOS-1707", "IOS-1618"]
-        },
-        "IOS-1707" : {
-            title: "task c",
-            status: "done",
-            owner: "sonia",
-            dependsOn: []
-        },
-        "IOS-1618" : {
-            title: "task d",
-            status: "done",
-            owner: "amat",
-            dependsOn: []
-        }
+var d = require('../../main/lib/drawer');
+
+module.exports.drawingTasks = {
+    "IOS-01" : {
+        title: "task a",
+        status: "blocker",
+        owner: "alan",
+        dependsOn: ["IOS-02"]
     },
-    expected: [
-        {
-            padding: 0,
-            task: "IOS-1617"
-        },
-        {
-            padding: 1,
-            task: "IOS-1619"
-        },
-        {
-            padding: 2,
-            task: "IOS-1707"
-        },
-        {
-            padding: 2,
-            task: "IOS-1618"
-        }
-    ]
+    "IOS-02" : {
+        title: "task b",
+        status: "partial",
+        owner: "brandon",
+        dependsOn: ["IOS-03", "IOS-04"]
+    },
+    "IOS-03" : {
+        title: "task c",
+        status: "done",
+        owner: "sonia",
+        dependsOn: []
+    },
+    "IOS-04" : {
+        title: "task d",
+        status: "done",
+        owner: "amat",
+        dependsOn: []
+    }
 };
 
-module.exports.multipleRootTasks = {
+module.exports.sampleDrawing = {
     input: {
-        "IOS-1617" : {
-            title: "task a",
-            status: "blocker",
-            owner: "alan",
-            dependsOn: ["IOS-1619"]
-        },
-        "IOS-1619" : {
-            title: "task b",
-            status: "partial",
-            owner: "brandon",
-            dependsOn: ["IOS-1707", "IOS-1618"]
-        },
-        "IOS-1707" : {
-            title: "task c",
-            status: "done",
-            owner: "sonia",
-            dependsOn: []
-        },
-        "IOS-1618" : {
-            title: "task d",
-            status: "done",
-            owner: "amat",
-            dependsOn: []
-        },
-        "IOS-1750" : {
-            title: "task A",
-            status: "partial",
-            owner: "amat",
-            dependsOn: ["IOS-1751"]
-        },
-        "IOS-1751" : {
-            title: "task B",
-            status: "done",
-            owner: "alan",
-            dependsOn: []
-        },
-
+      padding: 1,
+      task: 'IOS-01'
     },
     expected: [
-        {
-            padding: 0,
-            task: "IOS-1617"
-        },
-        {
-            padding: 1,
-            task: "IOS-1619"
-        },
-        {
-            padding: 2,
-            task: "IOS-1707"
-        },
-        {
-            padding: 2,
-            task: "IOS-1618"
-        },
-        {
-            padding: 0,
-            task: "IOS-1750"
-        },
-        {
-            padding: 1,
-            task: "IOS-1751"
-        }
-    ]
-};
-
-module.exports.multipleBlockingTasks = {
-    input: {
-        "IOS-01" : {
-            title: "task a",
-            status: "partial",
-            owner: "amat",
-            dependsOn: ["IOS-02", "IOS-03"]
-        },
-        "IOS-02" : {
-            title: "task b",
-            status: "blocker",
-            owner: "alan",
-            dependsOn: ["IOS-04"]
-        },
-        "IOS-03" : {
-            title: "task c",
-            status: "blocker",
-            owner: "brandon",
-            dependsOn: ["IOS-04"]
-        },
-        "IOS-04" : {
-            title: "task d",
-            status: "done",
-            owner: "sonia",
-            dependsOn: []
-        }
-    },
-    expected: [
-        {
-            padding: 0,
-            task: "IOS-01"
-        },
-        {
-            padding: 1,
-            task: "IOS-02"
-        },
-        {
-            padding: 2,
-            task: "IOS-04"
-        },
-        {
-            padding: 1,
-            task: "IOS-03"
-        },
-        {
-            padding: 2,
-            task: "IOS-04"
-        }
-    ]
-};
-
-module.exports.unorderedTasks = {
-    input: {
-        "IOS-1618" : {
-            title: "task d",
-            status: "done",
-            owner: "amat",
-            dependsOn: []
-        },
-        "IOS-1617" : {
-            title: "task a",
-            status: "blocker",
-            owner: "alan",
-            dependsOn: ["IOS-1619"]
-        },
-        "IOS-1619" : {
-            title: "task b",
-            status: "partial",
-            owner: "brandon",
-            dependsOn: ["IOS-1707", "IOS-1618"]
-        },
-        "IOS-1707" : {
-            title: "task c",
-            status: "done",
-            owner: "sonia",
-            dependsOn: []
-        }
-    },
-    expected: [
-        {
-            padding: 0,
-            task: "IOS-1617"
-        },
-        {
-            padding: 1,
-            task: "IOS-1619"
-        },
-        {
-            padding: 2,
-            task: "IOS-1707"
-        },
-        {
-            padding: 2,
-            task: "IOS-1618"
-        }
-    ]
+        d.ARROW,
+        d.DONE,
+        d.jiraLink('IOS-01'),
+        d.body(this.drawingTasks['IOS-01'])
+    ].join(" ")
 };

--- a/test/fixtures/parsing_fixture.js
+++ b/test/fixtures/parsing_fixture.js
@@ -1,0 +1,212 @@
+module.exports.tasks = {
+    input: {
+        "IOS-01" : {
+            title: "task a",
+            status: "blocker",
+            owner: "alan",
+            dependsOn: ["IOS-02"]
+        },
+        "IOS-02" : {
+            title: "task b",
+            status: "partial",
+            owner: "brandon",
+            dependsOn: ["IOS-03", "IOS-04"]
+        },
+        "IOS-03" : {
+            title: "task c",
+            status: "done",
+            owner: "sonia",
+            dependsOn: []
+        },
+        "IOS-04" : {
+            title: "task d",
+            status: "done",
+            owner: "amat",
+            dependsOn: []
+        }
+    },
+    expected: [
+        {
+            padding: 0,
+            task: "IOS-01"
+        },
+        {
+            padding: 1,
+            task: "IOS-02"
+        },
+        {
+            padding: 2,
+            task: "IOS-03"
+        },
+        {
+            padding: 2,
+            task: "IOS-04"
+        }
+    ]
+};
+
+module.exports.multipleRootTasks = {
+    input: {
+        "IOS-01" : {
+            title: "task a",
+            status: "blocker",
+            owner: "alan",
+            dependsOn: ["IOS-02"]
+        },
+        "IOS-02" : {
+            title: "task b",
+            status: "partial",
+            owner: "brandon",
+            dependsOn: ["IOS-03", "IOS-04"]
+        },
+        "IOS-03" : {
+            title: "task c",
+            status: "done",
+            owner: "sonia",
+            dependsOn: []
+        },
+        "IOS-04" : {
+            title: "task d",
+            status: "done",
+            owner: "amat",
+            dependsOn: []
+        },
+        "IOS-05" : {
+            title: "task A",
+            status: "partial",
+            owner: "amat",
+            dependsOn: ["IOS-06"]
+        },
+        "IOS-06" : {
+            title: "task B",
+            status: "done",
+            owner: "alan",
+            dependsOn: []
+        },
+
+    },
+    expected: [
+        {
+            padding: 0,
+            task: "IOS-01"
+        },
+        {
+            padding: 1,
+            task: "IOS-02"
+        },
+        {
+            padding: 2,
+            task: "IOS-03"
+        },
+        {
+            padding: 2,
+            task: "IOS-04"
+        },
+        {
+            padding: 0,
+            task: "IOS-05"
+        },
+        {
+            padding: 1,
+            task: "IOS-06"
+        }
+    ]
+};
+
+module.exports.multipleBlockingTasks = {
+    input: {
+        "IOS-01" : {
+            title: "task a",
+            status: "partial",
+            owner: "amat",
+            dependsOn: ["IOS-02", "IOS-03"]
+        },
+        "IOS-02" : {
+            title: "task b",
+            status: "blocker",
+            owner: "alan",
+            dependsOn: ["IOS-04"]
+        },
+        "IOS-03" : {
+            title: "task c",
+            status: "blocker",
+            owner: "brandon",
+            dependsOn: ["IOS-04"]
+        },
+        "IOS-04" : {
+            title: "task d",
+            status: "done",
+            owner: "sonia",
+            dependsOn: []
+        }
+    },
+    expected: [
+        {
+            padding: 0,
+            task: "IOS-01"
+        },
+        {
+            padding: 1,
+            task: "IOS-02"
+        },
+        {
+            padding: 2,
+            task: "IOS-04"
+        },
+        {
+            padding: 1,
+            task: "IOS-03"
+        },
+        {
+            padding: 2,
+            task: "IOS-04"
+        }
+    ]
+};
+
+module.exports.unorderedTasks = {
+    input: {
+        "IOS-04" : {
+            title: "task d",
+            status: "done",
+            owner: "amat",
+            dependsOn: []
+        },
+        "IOS-01" : {
+            title: "task a",
+            status: "blocker",
+            owner: "alan",
+            dependsOn: ["IOS-02"]
+        },
+        "IOS-02" : {
+            title: "task b",
+            status: "partial",
+            owner: "brandon",
+            dependsOn: ["IOS-03", "IOS-04"]
+        },
+        "IOS-03" : {
+            title: "task c",
+            status: "done",
+            owner: "sonia",
+            dependsOn: []
+        }
+    },
+    expected: [
+        {
+            padding: 0,
+            task: "IOS-01"
+        },
+        {
+            padding: 1,
+            task: "IOS-02"
+        },
+        {
+            padding: 2,
+            task: "IOS-03"
+        },
+        {
+            padding: 2,
+            task: "IOS-04"
+        }
+    ]
+};

--- a/test/parsingTests.js
+++ b/test/parsingTests.js
@@ -1,0 +1,35 @@
+var assert = require('chai').assert;
+var parser = require('../main/lib/parser');
+
+var testExamples = require('./fixtures/parsing_fixture');
+var tasks = testExamples.tasks;
+var multipleRootTasks = testExamples.multipleRootTasks;
+var multipleBlockingTasks = testExamples.multipleBlockingTasks;
+var unorderedTasks = testExamples.unorderedTasks;
+
+describe('Parser', function() {
+    describe('drawingInstructions()', function() {
+        it('yields drawing instructions ', function() {
+            assert.deepEqual(parser.getDrawingInstructions(tasks.input), tasks.expected);
+        });
+
+        context('when there are multiple root tasks', function() {
+            it('yeilds drawing instructions for each root', function() {
+                assert.deepEqual(parser.getDrawingInstructions(multipleRootTasks.input), multipleRootTasks.expected);
+            });
+        });
+
+        context('when there are multiple stories that are blocked on the same task', function() {
+            it('yeilds drawing instructions for each story along with the blocking task', function() {
+                assert.deepEqual(parser.getDrawingInstructions(multipleBlockingTasks.input), multipleBlockingTasks.expected);
+            });
+        });
+
+        context('when the tasks provided are unordered', function() {
+            it('solves the dependencies and yeilds drawing instructions', function() {
+                assert.deepEqual(parser.getDrawingInstructions(unorderedTasks.input), unorderedTasks.expected);
+            });
+        });
+    });
+});
+


### PR DESCRIPTION
Lets expand the scope of our tests against the drawer/parser object to have a better idea of what we want its behaviour to be. 

So far these are the examples I can think of: 
- [x] test that drawing instructions are correct given simple data of dependencies
- [x] test with multiple root stories (or multiple _features_)
- [x] test where two or more stories are blocked by the same item (_multipleBlockingTasks_)
- [x] test when the data does not order our tasks and we will have to solve the dependency ourselves (_ unorderedTasks_)

TODO: 
- Figure out the expected output when user asks with a dependent task. 
  - Candidate solution is to draw linked list of items up to the task in question.
    - If the dependent task is blocking multiple stories, draw the linked list for each.
- Do we want default filter behaviour to prevent drawing ALL stories? Should we have some filter data revolving stories in IOS, or Android, or web-eng (or is it too soon to think about this?)
